### PR TITLE
prevent unobserved exception when getting statistics from a dead silo

### DIFF
--- a/OrleansDashboard/DashboardModule.cs
+++ b/OrleansDashboard/DashboardModule.cs
@@ -94,9 +94,21 @@ namespace OrleansDashboard
             var address = SiloAddress.FromParsableString(parameters["address"]);
             var grain = this.ProviderRuntime.GrainFactory.GetGrain<IManagementGrain>(0);
 
-            var result = await Dispatch(async () => {
-                return (await grain.GetRuntimeStatistics(new SiloAddress[] { address })).FirstOrDefault();
+            var result = await Dispatch(async () =>
+            {
+                Dictionary<SiloAddress, SiloStatus> silos = await grain.GetHosts(true);
+
+                SiloStatus siloStatus;
+                if (silos.TryGetValue(address, out siloStatus))
+                {
+                    return (await grain.GetRuntimeStatistics(new SiloAddress[] { address })).FirstOrDefault();
+                }
+                else
+                {
+                    return null;
+                }
             });
+
 
             await context.ReturnJson(result);
         }


### PR DESCRIPTION
When viewing a single silo statistics, if you picked a silo that was dead I would get unobserved exceptions.

`Exc level 2: Orleans.Runtime.OrleansException: The target silo is no longer active: target was S172.18.124.91:11111:191609335, but this silo is S172.18.124.91:11111:191708862. The rejected message is Request S172.18.124.91:11111:191708862*grn/7483D9D2/00000000@32f88da7->S172.18.124.91:11111:191609335SiloControl@S0000000c #9812: global::Orleans.ISiloControl:GetRuntimeStatistics().	`

