### PR TITLE
Fix StatsPublisher error on silo shutdown

### DIFF
--- a/OrleansDashboard/StatsPublisher.cs
+++ b/OrleansDashboard/StatsPublisher.cs
@@ -64,7 +64,10 @@ namespace OrleansDashboard
 
         Task Dispatch(Func<Task> func)
         {
-            return Task.Factory.StartNew(func, CancellationToken.None, TaskCreationOptions.None, scheduler: Dashboard.OrleansScheduler);
+            var scheduler = Dashboard.OrleansScheduler;
+            return scheduler == null 
+                ? TaskDone.Done 
+                : Task.Factory.StartNew(func, CancellationToken.None, TaskCreationOptions.None, scheduler);
         }
     }
    


### PR DESCRIPTION
We often get `NullReferenceException` from `StatsPublisher` on deployment when `Dashboard.OrleansScheduler` is `null`. Nothing really important, but better to be fixed I guess