### PR TITLE
Add ISiloDetailsProvider, allows for custom implementations & SF integration

### DIFF
--- a/OrleansDashboard/DashboardCounters.cs
+++ b/OrleansDashboard/DashboardCounters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Orleans.Runtime;
 
 namespace OrleansDashboard
 {
@@ -41,6 +42,7 @@ namespace OrleansDashboard
         public string StartTime { get; set; }
         public string Status { get; set; }
         public int UpdateZone { get; set; }
+        public SiloStatus SiloStatus { get; set; }
     }
 
     public class DashboardCounters

--- a/OrleansDashboard/DashboardGrain.cs
+++ b/OrleansDashboard/DashboardGrain.cs
@@ -18,21 +18,9 @@ namespace OrleansDashboard
         private List<GrainTraceEntry> history = new List<GrainTraceEntry>();
 
 
-        private readonly ISiloDetailsProvider siloDetailsProvider;
+        private ISiloDetailsProvider siloDetailsProvider;
 
-        public DashboardGrain()
-        {
-            // note: normally we would use dependency injection
-            // but since we do not have access to the registered services collection 
-            // from within a bootstrapper we do it this way:
-            // first try to resolve from the container, if not present in container
-            // then instantiate the default
-            this.siloDetailsProvider =
-                (this.ServiceProvider.GetService(typeof(ISiloDetailsProvider)) as ISiloDetailsProvider)
-                ?? new MembershipTableSiloDetailsProvider(this.GrainFactory);
-
-        }
-
+      
 
         private async Task Callback(object _)
         {
@@ -102,6 +90,16 @@ namespace OrleansDashboard
 
         public override Task OnActivateAsync()
         {
+            // note: normally we would use dependency injection
+            // but since we do not have access to the registered services collection 
+            // from within a bootstrapper we do it this way:
+            // first try to resolve from the container, if not present in container
+            // then instantiate the default
+            this.siloDetailsProvider =
+                (this.ServiceProvider.GetService(typeof(ISiloDetailsProvider)) as ISiloDetailsProvider)
+                ?? new MembershipTableSiloDetailsProvider(this.GrainFactory);
+
+
             this.Counters = new DashboardCounters();
             this.RegisterTimer(this.Callback, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
             this.StartTime = DateTime.UtcNow;

--- a/OrleansDashboard/DashboardGrain.cs
+++ b/OrleansDashboard/DashboardGrain.cs
@@ -17,24 +17,41 @@ namespace OrleansDashboard
         private DateTime StartTime { get; set; }
         private List<GrainTraceEntry> history = new List<GrainTraceEntry>();
 
+
+        private readonly ISiloDetailsProvider siloDetailsProvider;
+
+        public DashboardGrain()
+        {
+            // note: normally we would use dependency injection
+            // but since we do not have access to the registered services collection 
+            // from within a bootstrapper we do it this way:
+            // first try to resolve from the container, if not present in container
+            // then instantiate the default
+            this.siloDetailsProvider =
+                (this.ServiceProvider.GetService(typeof(ISiloDetailsProvider)) as ISiloDetailsProvider)
+                ?? new MembershipTableSiloDetailsProvider(this.GrainFactory);
+
+        }
+
+
         private async Task Callback(object _)
         {
             var metricsGrain = this.GrainFactory.GetGrain<IManagementGrain>(0);
             var activationCountTask = metricsGrain.GetTotalActivationCount();
-            var hostsTask = metricsGrain.GetDetailedHosts(true);
             var simpleGrainStatsTask = metricsGrain.GetSimpleGrainStatistics();
+            var siloDetailsTask = siloDetailsProvider.GetSiloDetails();
 
-            await Task.WhenAll(activationCountTask, hostsTask, simpleGrainStatsTask);
+            await Task.WhenAll(activationCountTask,  simpleGrainStatsTask, siloDetailsTask);
 
-            RecalculateCounters(activationCountTask.Result, hostsTask.Result, simpleGrainStatsTask.Result);
+            RecalculateCounters(activationCountTask.Result, siloDetailsTask.Result, simpleGrainStatsTask.Result);
         }
 
-        internal void RecalculateCounters(int activationCount, IList<MembershipEntry> hosts,
+        internal void RecalculateCounters(int activationCount, SiloDetails[] hosts,
             IList<SimpleGrainStatistic> simpleGrainStatistics)
         {
             this.Counters.TotalActivationCount = activationCount;
 
-            this.Counters.TotalActiveHostCount = hosts.Count(x => x.Status == SiloStatus.Active);
+            this.Counters.TotalActiveHostCount = hosts.Count(x => x.SiloStatus == SiloStatus.Active);
             this.Counters.TotalActivationCountHistory.Enqueue(activationCount);
             this.Counters.TotalActiveHostCountHistory.Enqueue(this.Counters.TotalActiveHostCount);
 
@@ -50,19 +67,7 @@ namespace OrleansDashboard
             // TODO - whatever max elapsed time
             var elapsedTime = Math.Min((DateTime.UtcNow - this.StartTime).TotalSeconds, 100);
 
-            this.Counters.Hosts = hosts.Select(x => new SiloDetails
-            {
-                FaultZone = x.FaultZone,
-                HostName = x.HostName,
-                IAmAliveTime = x.IAmAliveTime.ToString("o"),
-                ProxyPort = x.ProxyPort,
-                RoleName = x.RoleName,
-                SiloAddress = x.SiloAddress.ToParsableString(),
-                SiloName = x.SiloName,
-                StartTime = x.StartTime.ToString("o"),
-                Status = x.Status.ToString(),
-                UpdateZone = x.UpdateZone
-            }).ToArray();
+            this.Counters.Hosts = hosts;
 
             var aggregatedTotals = this.history
                 .GroupBy(x => new GrainSiloKey(x.Grain, x.SiloAddress))

--- a/OrleansDashboard/ISiloDetailsProvider.cs
+++ b/OrleansDashboard/ISiloDetailsProvider.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans;
+using Orleans.CodeGeneration;
+using Orleans.Runtime;
+
+namespace OrleansDashboard
+{
+    public interface ISiloDetailsProvider
+    {
+        Task<SiloDetails[]> GetSiloDetails();
+    }
+
+    /// <summary>
+    /// Simple silo details provider
+    /// Uses ISiloStatusOracle internally
+    /// </summary>
+    public sealed class SiloStatusOracleSiloDetailsProvider : ISiloDetailsProvider
+    {
+        private readonly ISiloStatusOracle siloStatusOracle;
+
+        public SiloStatusOracleSiloDetailsProvider(ISiloStatusOracle siloStatusOracle)
+        {
+            this.siloStatusOracle = siloStatusOracle;
+        }
+
+        public Task<SiloDetails[]> GetSiloDetails()
+        {
+            // todo this could be improved by using a ISiloStatusListener
+            // and caching / projecting the changes instead of polling
+            // should reduce allocations of array's etc
+        
+            return Task.FromResult(siloStatusOracle.GetApproximateSiloStatuses(true)
+                .Select(x => new SiloDetails()
+                {
+                    Status = x.Value.ToString(),
+                    SiloStatus = x.Value,
+                    SiloAddress = x.Key.ToParsableString(),
+                    SiloName = x.Key.ToParsableString() //use the address for naming
+                })
+                .ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Default silo details provider
+    /// Uses IManagementGrain internally.
+    /// <remarks>Do not use if there is no membershiptable. use <see cref="SiloStatusOracleSiloDetailsProvider"/> 
+    /// instead.</remarks>
+    /// </summary>
+    public sealed class MembershipTableSiloDetailsProvider : ISiloDetailsProvider
+    {
+        private readonly IGrainFactory grainFactory;
+
+        public MembershipTableSiloDetailsProvider(IGrainFactory grainFactory)
+        {
+            this.grainFactory = grainFactory;
+        }
+
+        public async Task<SiloDetails[]> GetSiloDetails()
+        {
+            //default implementation uses managementgrain details
+            var grain = grainFactory.GetGrain<IManagementGrain>(0);
+
+            var hosts = await grain.GetDetailedHosts(true);
+
+            return hosts.Select(x => new SiloDetails
+            {
+                FaultZone = x.FaultZone,
+                HostName = x.HostName,
+                IAmAliveTime = x.IAmAliveTime.ToString("o"),
+                ProxyPort = x.ProxyPort,
+                RoleName = x.RoleName,
+                SiloAddress = x.SiloAddress.ToParsableString(),
+                SiloName = x.SiloName,
+                StartTime = x.StartTime.ToString("o"),
+                Status = x.Status.ToString(),
+                SiloStatus = x.Status,
+                UpdateZone = x.UpdateZone
+            }).ToArray();
+        }
+    }
+}

--- a/OrleansDashboard/OrleansDashboard.csproj
+++ b/OrleansDashboard/OrleansDashboard.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Core" Version="1.5.0-beta1" />
     <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator" Version="1.5.0-beta1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="1.5.0-beta1" />
     <PackageReference Include="Microsoft.Owin.Hosting" Version="3.0.1" />
     <PackageReference Include="Nowin" Version="0.26.0" />
   </ItemGroup>

--- a/PerformanceTests/DashboardGrainBenchmark.cs
+++ b/PerformanceTests/DashboardGrainBenchmark.cs
@@ -16,6 +16,7 @@ namespace PerformanceTests
         private DashboardGrain _dashboardGrain;
         private List<SimpleGrainStatistic> _simpleGrainStatistics;
         private int _totalActivationCount;
+        private SiloDetails[] _siloDetails;
 
         [Params(3)]
         public int SiloCount { get; set; }
@@ -48,6 +49,11 @@ namespace PerformanceTests
                     SiloAddress = SiloAddress.NewLocalAddress(i)
                 });
             }
+            _siloDetails = _silos.Select(x => new SiloDetails()
+            {
+                SiloAddress = x.SiloAddress.ToParsableString()
+            }).ToArray();
+
             _grainTypes = new List<string>();
             for (int i = 0; i < GrainTypeCount; i++)
             {
@@ -106,7 +112,7 @@ namespace PerformanceTests
         [Benchmark]
         public void Recalculate()
         {
-            _dashboardGrain.RecalculateCounters(_totalActivationCount, _silos, _simpleGrainStatistics);
+            _dashboardGrain.RecalculateCounters(_totalActivationCount, _siloDetails, _simpleGrainStatistics);
         }
     }
 }


### PR DESCRIPTION
this PR contains a solution for #47 

I've added an ISiloDetailsProvider which is resolved from the runtime if it is provided.
Default behavior is to use the host details provided by IManagementGrain using the membershiptable.

