### PR TITLE
Support for message-based grains (uniform api)

### DIFF
--- a/TestGrains/TestMessageBasedGrain.cs
+++ b/TestGrains/TestMessageBasedGrain.cs
@@ -1,0 +1,24 @@
+﻿using Orleans;
+using System;
+using System.Threading.Tasks;
+
+namespace TestGrains
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class MessageArgumentAttribute : Attribute
+    {}
+
+    public interface ITestMessageBasedGrain : IGrainWithIntegerKey
+    {
+        Task Receive(object message);
+    }
+
+    public class TestMessageBasedGrain : Grain, ITestMessageBasedGrain
+    {
+        [MessageArgument]
+        public Task Receive(object message)
+        {
+            return TaskDone.Done;
+        }
+    }
+}

--- a/TestHost/Program.cs
+++ b/TestHost/Program.cs
@@ -41,6 +41,10 @@ namespace TestHost
 
         private static async Task CallGenerator(IClusterClient client, CancellationTokenSource tokenSource)
         {
+            var a = client.GetGrain<ITestMessageBasedGrain>(42);
+            a.Receive("string").Wait();
+            a.Receive(DateTime.UtcNow).Wait();
+
             var x = client.GetGrain<ITestGenericGrain<string, int>>("test");
             x.TestT("string").Wait();
             x.TestU(1).Wait();


### PR DESCRIPTION
Heads up from Orleankka!

For long time Orleankka users were missing such useful metric as requests\errors\latency per sec since the tracing was done against method name and as you know all grains generated by Orleankka have uniform api (i.e. singe `Receive` method.) and as a result all calls were aggregated under single label.

I've tried to make this integration non-intrusive and to have as less coupling as possible, so I've used the trick from .NET framework and did integration based on simple convention.

Hope it's alright. If you can propose better alternatives I'm ok to redo. Thanks!