### PR TITLE
reminders - Feat/add go to last

### DIFF
--- a/App/reminders/reminders.jsx
+++ b/App/reminders/reminders.jsx
@@ -6,9 +6,10 @@ var Panel = require('../components/panel.jsx');
 
 module.exports = React.createClass({
     render:function(){
+        var totalPages =  this.props.remindersData.count / 25;
         var showPrevious = this.props.page > 1;
         var showNext = this.props.remindersData.reminders.length == 25;
-
+        var showLast = totalPages / 25 > this.props.page;
         return <div>
             <div className="row">
                 <div className="col-md-12">
@@ -22,6 +23,8 @@ module.exports = React.createClass({
                   {showPrevious ? <a className="btn btn-default bg-purple" href={`#/reminders/${this.props.page - 1}`}><i className="fa fa-arrow-circle-left"></i> Previous</a> : null}
                   <span> </span>
                   {showNext ? <a className="btn btn-default bg-purple" href={`#/reminders/${this.props.page + 1}`}>Next <i className="fa fa-arrow-circle-right"></i></a> : null}
+                  <span> </span>
+                  {showLast ? <a className="btn btn-default bg-purple" href={`#/reminders/${totalPages}`}>Last ({this.props.totalPages}) <i className="fa fa-arrow-circle-right"></i></a> : null}
                 </div>
               </div>
             </Panel>

--- a/App/reminders/reminders.jsx
+++ b/App/reminders/reminders.jsx
@@ -6,7 +6,7 @@ var Panel = require('../components/panel.jsx');
 
 module.exports = React.createClass({
     render:function(){
-        var totalPages =  this.props.remindersData.count / 25;
+        var totalPages =  Math.ceil(this.props.remindersData.count / 25);
         var showFirst = this.props.page > 2;
         var showPrevious = this.props.page > 1;
         var showNext = totalPages > this.props.page;
@@ -27,7 +27,7 @@ module.exports = React.createClass({
                   <span> </span>
                   {showNext ? <a className="btn btn-default bg-purple" href={`#/reminders/${this.props.page + 1}`}>Next <i className="fa fa-arrow-circle-right"></i></a> : null}
                   <span> </span>
-                  {showLast ? <a className="btn btn-default bg-purple" href={`#/reminders/${totalPages}`}>Last ({this.props.totalPages}) <i className="fa fa-arrow-circle-right"></i></a> : null}
+                  {showLast ? <a className="btn btn-default bg-purple" href={`#/reminders/${totalPages}`}>Last <i className="fa fa-arrow-circle-right"></i></a> : null}
                 </div>
               </div>
             </Panel>

--- a/App/reminders/reminders.jsx
+++ b/App/reminders/reminders.jsx
@@ -7,6 +7,7 @@ var Panel = require('../components/panel.jsx');
 module.exports = React.createClass({
     render:function(){
         var totalPages =  this.props.remindersData.count / 25;
+        var showFirst = this.props.page > 2;
         var showPrevious = this.props.page > 1;
         var showNext = totalPages > this.props.page;
         var showLast = totalPages > this.props.page + 1;
@@ -20,6 +21,8 @@ module.exports = React.createClass({
               <div>
                 <ReminderTable data={this.props.remindersData.reminders}/>
                 <div style={{textAlign:"center"}}>
+                  {showFirst ? <a className="btn btn-default bg-purple" href={'#/reminders/1'}><i className="fa fa-arrow-circle-left"></i> First</a> : null}
+                  <span> </span>
                   {showPrevious ? <a className="btn btn-default bg-purple" href={`#/reminders/${this.props.page - 1}`}><i className="fa fa-arrow-circle-left"></i> Previous</a> : null}
                   <span> </span>
                   {showNext ? <a className="btn btn-default bg-purple" href={`#/reminders/${this.props.page + 1}`}>Next <i className="fa fa-arrow-circle-right"></i></a> : null}

--- a/App/reminders/reminders.jsx
+++ b/App/reminders/reminders.jsx
@@ -8,8 +8,8 @@ module.exports = React.createClass({
     render:function(){
         var totalPages =  this.props.remindersData.count / 25;
         var showPrevious = this.props.page > 1;
-        var showNext = this.props.remindersData.reminders.length == 25;
-        var showLast = totalPages / 25 > this.props.page;
+        var showNext = totalPages > this.props.page;
+        var showLast = totalPages > this.props.page + 1;
         return <div>
             <div className="row">
                 <div className="col-md-12">


### PR DESCRIPTION
Currently you either have to guess which is the last page, or press "Next" multiple times
This PR aims to fix that by adding a "Last" button which takes you to the last page.
Its based on the total count (which exists on the response), divided by 25.

Also, the "showNext" button wasn't calculated right, as it assumes that another page exists if there are 25, it is now calculated by totalPages > page