### PR TITLE
Feat/reminders/add filters

### DIFF
--- a/App/components/reminder-table.jsx
+++ b/App/components/reminder-table.jsx
@@ -3,7 +3,7 @@ var React = require('react');
 
 module.exports = React.createClass({
     getInitialState: function() {
-        return {grain_reference: null, primary_key: null, name: null, startAt: null, period: null};
+        return {grain_reference: '', primary_key: '', name: '', startAt: '', period: ''};
     },
     handleChange: function(e) {
         this.setState({

--- a/App/index.jsx
+++ b/App/index.jsx
@@ -238,11 +238,16 @@ routie('/reminders/:page?', function(page){
         renderPage(<Page title="Reminders"><Reminders remindersData={remindersData} page={page} /></Page>, "#/reminders");
     }
 
+    var rerouteToLastPage = function(lastPage){
+        return document.location.hash = `/reminders/${lastPage}`
+    }
+
     var loadData = function(cb){
         http.get(`/Reminders/${page}`, function(err, data){
             var maxLastPage = Math.ceil(data.count / 25);
             if (page > maxLastPage)
-                return document.location.hash = `/reminders/${maxLastPage}`
+                 rerouteToLastPage(maxLastPage)
+            else
             remindersData = data;
             renderReminders();
         });

--- a/App/index.jsx
+++ b/App/index.jsx
@@ -240,6 +240,9 @@ routie('/reminders/:page?', function(page){
 
     var loadData = function(cb){
         http.get(`/Reminders/${page}`, function(err, data){
+            var maxLastPage = Math.ceil(data.count / 25);
+            if (page > maxLastPage)
+                return document.location.hash = `/reminders/${maxLastPage}`
             remindersData = data;
             renderReminders();
         });


### PR DESCRIPTION
Another issue which bugged me was that it remembered previous reminder pages in my browser, though that page wasn't the last page anymore. It would return an empty list of Reminders.

This PR reroutes (by calculating the lastPage and creating a new request) to the last page which has reminders

BTW - good time to say this is a great project, keep up the good work