### PR TITLE
Upgrade to RC2

### DIFF
--- a/OrleansDashboard/OrleansDashboard.csproj
+++ b/OrleansDashboard/OrleansDashboard.csproj
@@ -8,7 +8,7 @@
     <PackageTags>orleans dashboard metrics monitor</PackageTags>
     <Description>An admin dashboard for Microsoft Orleans</Description>
     <Company>OrleansContrib</Company>
-    <Version>2.0.0-rc2</Version>
+    <Version>2.0.0-rc2a</Version>
     <Copyright>Copyright © 2017</Copyright>
     <Authors>OrleansContrib</Authors>
     <PackageIconUrl>http://dotnet.github.io/orleans/assets/logo.png</PackageIconUrl>
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-r2" />
   </ItemGroup>
 </Project>

--- a/OrleansDashboard/ServiceCollectionExtensions.cs
+++ b/OrleansDashboard/ServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ namespace Orleans
             Action<DashboardOptions> configurator = null)
         {
             services.Configure(configurator ?? (x => { }));
-            services.AddIncomingGrainCallFilter<GrainProfiler>();
+            services.AddGrainCallFilter<GrainProfiler>();
             services.AddSingleton<SiloStatusOracleSiloDetailsProvider>();
             services.AddSingleton<MembershipTableSiloDetailsProvider>();
             services.AddSingleton(DashboardLogger.Instance);

--- a/TestGrains/TestGrains.csproj
+++ b/TestGrains/TestGrains.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc2" />
   </ItemGroup>
 </Project>

--- a/TestHost/Program.cs
+++ b/TestHost/Program.cs
@@ -31,7 +31,6 @@ namespace TestHost
                     .UseDevelopmentClustering(options => options.PrimarySiloEndpoint = new IPEndPoint(siloAddress, siloPort))
                     .UseInMemoryReminderService()
                     .ConfigureEndpoints(siloAddress, siloPort, gatewayPort)
-                    .Configure(options => options.ClusterId = "helloworldcluster")
                     .ConfigureApplicationParts(appParts => appParts.AddApplicationPart(typeof(TestCalls).Assembly))
                     .ConfigureLogging(builder =>
                     {
@@ -44,7 +43,6 @@ namespace TestHost
             var client =
                 new ClientBuilder()
                     .UseStaticClustering(options => options.Gateways.Add((new IPEndPoint(siloAddress, gatewayPort)).ToGatewayUri()))
-                    .ConfigureCluster(options => options.ClusterId = "helloworldcluster")
                     .ConfigureApplicationParts(appParts => appParts.AddApplicationPart(typeof(TestCalls).Assembly))
                     .ConfigureLogging(builder =>
                     {

--- a/TestHost/TestHost.csproj
+++ b/TestHost/TestHost.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Counters" Version="2.0.0-rc2" />
     <PackageReference Include="System.Management" Version="4.5.0-preview1-26216-02" />
   </ItemGroup>
 

--- a/TestHostSeparate/Program.cs
+++ b/TestHostSeparate/Program.cs
@@ -31,7 +31,6 @@ namespace TestHostSeparate
                     .UseDevelopmentClustering(options => options.PrimarySiloEndpoint = new IPEndPoint(siloAddress, siloPort))
                     .UseInMemoryReminderService()
                     .ConfigureEndpoints(siloAddress, siloPort, gatewayPort)
-                    .Configure(options => options.ClusterId = "helloworldcluster")
                     .ConfigureApplicationParts(appParts => appParts.AddApplicationPart(typeof(TestCalls).Assembly))
                     .ConfigureLogging(builder =>
                     {
@@ -45,7 +44,6 @@ namespace TestHostSeparate
                 new ClientBuilder()
                     .UseDashboard()
                     .UseStaticClustering(options => options.Gateways.Add((new IPEndPoint(siloAddress, gatewayPort)).ToGatewayUri()))
-                    .ConfigureCluster(options => options.ClusterId = "helloworldcluster")
                     .ConfigureApplicationParts(appParts => appParts.AddApplicationPart(typeof(TestCalls).Assembly))
                     .ConfigureLogging(builder =>
                     {

--- a/TestHostSeparate/TestHostSeparate.csproj
+++ b/TestHostSeparate/TestHostSeparate.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc1" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.0.0-rc2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.0.0-rc2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed that `AddGrainCallFilter()` is marked as obsolete, but `AddIncomingGrainCallFilter()` isn't there.