### PR TITLE
added benchmark for 'Add'

### DIFF
--- a/PerformanceTests/DashboardGrainBenchmark.cs
+++ b/PerformanceTests/DashboardGrainBenchmark.cs
@@ -35,15 +35,17 @@ namespace PerformanceTests
 
         // multiple implementations of trace history could be tested here
         ITraceHistory traceHistory = new TraceHistory();
-     
-        /* 
+        int time = 0;
+        DateTime startTime = DateTime.UtcNow;
+        
+
         [Benchmark]
         public void Test_Add_TraceHistory()
         {
-            AddTraceData(DateTime.UtcNow, traceHistory);
+            var now = startTime.AddSeconds(time++);
+            AddTraceData(now, traceHistory);
         }
-        */
-
+        
         [Benchmark]
         public void Test_QueryAll_TraceHistory()
         {


### PR DESCRIPTION
...although the number is kind of relative, as it represents multiple add operations (one for each silo, of which there are 10).
```
                                Method | SiloCount | GrainTypeCount | GrainMethodCount | HistorySize |      Mean |      Error |      StdDev |
-------------------------------------- |---------- |--------------- |----------------- |------------ |----------:|-----------:|------------:|
                 Test_Add_TraceHistory |        10 |             50 |               10 |         100 | 936.34 ms | 58.0484 ms | 170.2459 ms |
            Test_QueryAll_TraceHistory |        10 |             50 |               10 |         100 |  75.91 ms |  3.5889 ms |  10.0638 ms |
           Test_QuerySilo_TraceHistory |        10 |             50 |               10 |         100 |  19.38 ms |  0.3832 ms |   0.3763 ms |
          Test_QueryGrain_TraceHistory |        10 |             50 |               10 |         100 |  12.86 ms |  0.4066 ms |   0.5701 ms |
 Test_GroupByGrainAndSilo_TraceHistory |        10 |             50 |               10 |         100 | 114.95 ms |  6.3678 ms |  18.1678 ms |
```