### PR TITLE
Make calls immutable.

### DIFF
--- a/OrleansDashboard/DashboardCounters.cs
+++ b/OrleansDashboard/DashboardCounters.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Orleans.Runtime;
 
@@ -61,21 +62,21 @@ namespace OrleansDashboard
         {
             Hosts = new SiloDetails[0];
             SimpleGrainStats = new SimpleGrainStatisticCounter[0];
-            TotalActivationCountHistory = new Queue<int>();
-            TotalActiveHostCountHistory = new Queue<int>();
+            TotalActivationCountHistory = ImmutableQueue<int>.Empty;
+            TotalActiveHostCountHistory = ImmutableQueue<int>.Empty;
             foreach (var x in Enumerable.Range(1, Dashboard.HistoryLength))
             {
-                TotalActivationCountHistory.Enqueue(0);
-                TotalActiveHostCountHistory.Enqueue(0);
+                TotalActivationCountHistory = TotalActivationCountHistory.Enqueue(0);
+                TotalActiveHostCountHistory = TotalActiveHostCountHistory.Enqueue(0);
             }
         }
 
         public int TotalActiveHostCount { get; set; }
-        public Queue<int> TotalActiveHostCountHistory { get; set; }
+        public ImmutableQueue<int> TotalActiveHostCountHistory { get; set; }
         public SiloDetails[] Hosts { get; set; }
         public SimpleGrainStatisticCounter[] SimpleGrainStats { get; set; }
         public int TotalActivationCount { get; set; }
-        public Queue<int> TotalActivationCountHistory { get; set; }
+        public ImmutableQueue<int> TotalActivationCountHistory { get; set; }
     }
 
     internal class AggregatedGrainTotals

--- a/OrleansDashboard/DashboardGrain.cs
+++ b/OrleansDashboard/DashboardGrain.cs
@@ -48,17 +48,8 @@ namespace OrleansDashboard
             counters.TotalActivationCount = activationCount;
 
             counters.TotalActiveHostCount = hosts.Count(x => x.SiloStatus == SiloStatus.Active);
-            counters.TotalActivationCountHistory.Enqueue(activationCount);
-            counters.TotalActiveHostCountHistory.Enqueue(counters.TotalActiveHostCount);
-
-            while (counters.TotalActivationCountHistory.Count > Dashboard.HistoryLength)
-            {
-                counters.TotalActivationCountHistory.Dequeue();
-            }
-            while (counters.TotalActiveHostCountHistory.Count > Dashboard.HistoryLength)
-            {
-                counters.TotalActiveHostCountHistory.Dequeue();
-            }
+            counters.TotalActivationCountHistory = counters.TotalActivationCountHistory.Enqueue(activationCount).Dequeue();
+            counters.TotalActiveHostCountHistory = counters.TotalActiveHostCountHistory.Enqueue(counters.TotalActiveHostCount).Dequeue();
 
             // TODO - whatever max elapsed time
             var elapsedTime = Math.Min((DateTime.UtcNow - startTime).TotalSeconds, 100);
@@ -110,9 +101,9 @@ namespace OrleansDashboard
             return base.OnActivateAsync();
         }
 
-        public Task<DashboardCounters> GetCounters()
+        public Task<Immutable<DashboardCounters>> GetCounters()
         {
-            return Task.FromResult(counters);
+            return Task.FromResult(counters.AsImmutable());
         }
 
         public Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain)

--- a/OrleansDashboard/DashboardGrain.cs
+++ b/OrleansDashboard/DashboardGrain.cs
@@ -112,7 +112,7 @@ namespace OrleansDashboard
 
         public Task<DashboardCounters> GetCounters()
         {
-            return Task.FromResult(counters.AsImmutable());
+            return Task.FromResult(counters);
         }
 
         public Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain)

--- a/OrleansDashboard/DashboardGrain.cs
+++ b/OrleansDashboard/DashboardGrain.cs
@@ -18,10 +18,10 @@ namespace OrleansDashboard
     {
         const int DefaultTimerIntervalMs = 1000; // 1 second
         private static readonly TimeSpan DefaultTimerInterval = TimeSpan.FromSeconds(1);
-        private readonly DashboardCounters counters = new DashboardCounters();
         private readonly ITraceHistory history = new TraceHistory();
         private readonly DashboardOptions options;
         private readonly ISiloDetailsProvider siloDetailsProvider;
+        private DashboardCounters counters = new DashboardCounters();
         private DateTime startTime = DateTime.UtcNow;
 
         public DashboardGrain(IOptions<DashboardOptions> options, ISiloDetailsProvider siloDetailsProvider)
@@ -112,25 +112,25 @@ namespace OrleansDashboard
 
         public Task<DashboardCounters> GetCounters()
         {
-            return Task.FromResult(counters);
+            return Task.FromResult(counters.AsImmutable());
         }
 
-        public Task<Dictionary<string, Dictionary<string, GrainTraceEntry>>> GetGrainTracing(string grain)
+        public Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain)
         {
-            return Task.FromResult(history.QueryGrain(grain));
+            return Task.FromResult(history.QueryGrain(grain).AsImmutable());
         }
 
-        public Task<Dictionary<string, GrainTraceEntry>> GetClusterTracing()
+        public Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetClusterTracing()
         {
-            return Task.FromResult(this.history.QueryAll());
+            return Task.FromResult(this.history.QueryAll().AsImmutable());
         }
 
-        public Task<Dictionary<string, GrainTraceEntry>> GetSiloTracing(string address)
+        public Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetSiloTracing(string address)
         {
-            return Task.FromResult(this.history.QuerySilo(address));
+            return Task.FromResult(this.history.QuerySilo(address).AsImmutable());
         }
 
-        public Task<Dictionary<string, GrainMethodAggregate[]>> TopGrainMethods()
+        public Task<Immutable<Dictionary<string, GrainMethodAggregate[]>>> TopGrainMethods()
         {
             const int numberOfResultsToReturn = 5;
             
@@ -140,8 +140,7 @@ namespace OrleansDashboard
                 { "calls", values.OrderByDescending(x => x.Count).Take(numberOfResultsToReturn).ToArray() },
                 { "latency", values.OrderByDescending(x => x.ElapsedTime / (double) x.Count).Take(numberOfResultsToReturn).ToArray() },
                 { "errors", values.Where(x => x.ExceptionCount > 0 && x.Count > 0).OrderByDescending(x => x.ExceptionCount / x.Count).Take(numberOfResultsToReturn).ToArray() },
-            });
-
+            }.AsImmutable());
         }
 
       
@@ -151,9 +150,9 @@ namespace OrleansDashboard
             return Task.CompletedTask;
         }
 
-        public Task SubmitTracing(string siloAddress, SiloGrainTraceEntry[] grainTrace)
+        public Task SubmitTracing(string siloAddress, Immutable<SiloGrainTraceEntry[]> grainTrace)
         {
-            history.Add(DateTime.UtcNow, siloAddress, grainTrace);
+            history.Add(DateTime.UtcNow, siloAddress, grainTrace.Value);
 
             return Task.CompletedTask;
         }

--- a/OrleansDashboard/DashboardMiddleware.cs
+++ b/OrleansDashboard/DashboardMiddleware.cs
@@ -83,7 +83,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<IDashboardGrain>(0);
                 var result = await dispatcher.DispatchAsync(grain.GetClusterTracing).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }
@@ -95,7 +95,7 @@ namespace OrleansDashboard
                     var grain = grainFactory.GetGrain<IDashboardRemindersGrain>(0);
                     var result = await dispatcher.DispatchAsync(() => grain.GetReminders(1, REMINDER_PAGE_SIZE)).ConfigureAwait(false);
 
-                    await WriteJson(context, result);
+                    await WriteJson(context, result.Value);
                 }
                 catch
                 {
@@ -113,7 +113,7 @@ namespace OrleansDashboard
                     var grain = grainFactory.GetGrain<IDashboardRemindersGrain>(0);
                     var result = await dispatcher.DispatchAsync(() => grain.GetReminders(page, REMINDER_PAGE_SIZE)).ConfigureAwait(false);
 
-                    await WriteJson(context, result);
+                    await WriteJson(context, result.Value);
                 }
                 catch
                 {
@@ -129,7 +129,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<ISiloGrain>(remaining.ToValue());
                 var result = await dispatcher.DispatchAsync(grain.GetRuntimeStatistics).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }
@@ -139,7 +139,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<ISiloGrain>(address1.ToValue());
                 var result = await dispatcher.DispatchAsync(grain.GetExtendedProperties).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }
@@ -149,7 +149,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<IDashboardGrain>(0);
                 var result = await dispatcher.DispatchAsync(() => grain.GetSiloTracing(address2.ToValue())).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }
@@ -159,7 +159,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<ISiloGrain>(address3.ToValue());
                 var result = await dispatcher.DispatchAsync(grain.GetCounters).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }
@@ -169,7 +169,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<IDashboardGrain>(0);
                 var result = await dispatcher.DispatchAsync(() => grain.GetGrainTracing(grainName1.ToValue())).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }
@@ -179,7 +179,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<IDashboardGrain>(0);
                 var result = await dispatcher.DispatchAsync(() => grain.TopGrainMethods()).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }

--- a/OrleansDashboard/DashboardMiddleware.cs
+++ b/OrleansDashboard/DashboardMiddleware.cs
@@ -73,7 +73,7 @@ namespace OrleansDashboard
                 var grain = grainFactory.GetGrain<IDashboardGrain>(0);
                 var result = await dispatcher.DispatchAsync(grain.GetCounters).ConfigureAwait(false);
 
-                await WriteJson(context, result);
+                await WriteJson(context, result.Value);
 
                 return;
             }

--- a/OrleansDashboard/DashboardRemindersGrain.cs
+++ b/OrleansDashboard/DashboardRemindersGrain.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Concurrency;
 
 namespace OrleansDashboard
 {
@@ -13,22 +14,22 @@ namespace OrleansDashboard
             _reminderTable = reminderTable;
         }
 
-        public async Task<ReminderResponse> GetReminders(int pageNumber, int pageSize)
+        public async Task<Immutable<ReminderResponse>> GetReminders(int pageNumber, int pageSize)
         {
             var reminderData = await _reminderTable.ReadRows(0, 0xffffffff);
 
-            return new ReminderResponse {
-
+            return new ReminderResponse
+            {
                 Reminders = reminderData
                     .Reminders
                     .OrderBy(x => x.StartAt)
-                    .Skip((pageNumber -1) * pageSize)
+                    .Skip((pageNumber - 1) * pageSize)
                     .Take(pageSize)
                     .Select(ToReminderInfo)
                     .ToArray(),
 
                 Count = reminderData.Reminders.Count
-            }; 
+            }.AsImmutable();
         }
 
         private static ReminderInfo ToReminderInfo(ReminderEntry entry)

--- a/OrleansDashboard/DashboardTelemetryProducer.cs
+++ b/OrleansDashboard/DashboardTelemetryProducer.cs
@@ -1,4 +1,5 @@
 ﻿using Orleans;
+using Orleans.Concurrency;
 using Orleans.Runtime;
 using System;
 using System.Collections.Concurrent;
@@ -110,7 +111,7 @@ namespace OrleansDashboard
                 {
                     var countersArray = counters.ToArray();
 
-                    dispatcher.DispatchAsync(() => grain.ReportCounters(countersArray));
+                    dispatcher.DispatchAsync(() => grain.ReportCounters(countersArray.AsImmutable()));
                 }
             }
         }

--- a/OrleansDashboard/GrainProfiler.cs
+++ b/OrleansDashboard/GrainProfiler.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Orleans;
 using Microsoft.Extensions.Logging;
 using Orleans.Runtime;
+using Orleans.Concurrency;
 
 namespace OrleansDashboard
 {
@@ -130,7 +131,7 @@ namespace OrleansDashboard
                     {
                         var dashboardGrain = grainFactory.GetGrain<IDashboardGrain>(0);
 
-                        await dashboardGrain.SubmitTracing(siloAddress, items).ConfigureAwait(false);
+                        await dashboardGrain.SubmitTracing(siloAddress, items.AsImmutable()).ConfigureAwait(false);
                     }).Wait(30000);
                 }
                 catch (Exception ex)

--- a/OrleansDashboard/IDashboardGrain.cs
+++ b/OrleansDashboard/IDashboardGrain.cs
@@ -12,6 +12,7 @@ namespace OrleansDashboard
 
         Task<DashboardCounters> GetCounters();
 
+        [OneWay]
         Task SubmitTracing(string siloAddress, Immutable<SiloGrainTraceEntry[]> grainCallTime);
 
         Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain);

--- a/OrleansDashboard/IDashboardGrain.cs
+++ b/OrleansDashboard/IDashboardGrain.cs
@@ -8,12 +8,13 @@ namespace OrleansDashboard
 {
     public interface IDashboardGrain : IGrainWithIntegerKey
     {
+        [OneWay]
         Task Init();
-
-        Task<DashboardCounters> GetCounters();
 
         [OneWay]
         Task SubmitTracing(string siloAddress, Immutable<SiloGrainTraceEntry[]> grainCallTime);
+
+        Task<Immutable<DashboardCounters>> GetCounters();
 
         Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain);
 

--- a/OrleansDashboard/IDashboardGrain.cs
+++ b/OrleansDashboard/IDashboardGrain.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Orleans;
+using Orleans.Concurrency;
 using OrleansDashboard.History;
 
 namespace OrleansDashboard
@@ -11,14 +12,14 @@ namespace OrleansDashboard
 
         Task<DashboardCounters> GetCounters();
 
-        Task SubmitTracing(string siloAddress, SiloGrainTraceEntry[] grainCallTime);
+        Task SubmitTracing(string siloAddress, Immutable<SiloGrainTraceEntry[]> grainCallTime);
 
-        Task<Dictionary<string, Dictionary<string, GrainTraceEntry>>> GetGrainTracing(string grain);
+        Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain);
 
-        Task<Dictionary<string, GrainTraceEntry>> GetClusterTracing();
+        Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetClusterTracing();
 
-        Task<Dictionary<string, GrainTraceEntry>> GetSiloTracing(string address);
+        Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetSiloTracing(string address);
 
-        Task<Dictionary<string, GrainMethodAggregate[]>> TopGrainMethods();
+        Task<Immutable<Dictionary<string, GrainMethodAggregate[]>>> TopGrainMethods();
     }
 }

--- a/OrleansDashboard/IDashboardRemindersGrain.cs
+++ b/OrleansDashboard/IDashboardRemindersGrain.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Orleans;
+using Orleans.Concurrency;
 
 namespace OrleansDashboard
 {
@@ -12,6 +13,6 @@ namespace OrleansDashboard
 
     public interface IDashboardRemindersGrain : IGrainWithIntegerKey
     {
-        Task<ReminderResponse> GetReminders(int pageNumber, int pageSize);
+        Task<Immutable<ReminderResponse>> GetReminders(int pageNumber, int pageSize);
     }
 }

--- a/OrleansDashboard/ISiloGrain.cs
+++ b/OrleansDashboard/ISiloGrain.cs
@@ -1,4 +1,5 @@
 ﻿using Orleans;
+using Orleans.Concurrency;
 using Orleans.Runtime;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -18,12 +19,12 @@ namespace OrleansDashboard
     {
         Task SetVersion(string orleans, string host);
 
-        Task ReportCounters(StatCounter[] stats);
+        Task ReportCounters(Immutable<StatCounter[]> stats);
 
-        Task<Dictionary<string,string>> GetExtendedProperties();
+        Task<Immutable<Dictionary<string,string>>> GetExtendedProperties();
 
-        Task<SiloRuntimeStatistics[]> GetRuntimeStatistics();
+        Task<Immutable<SiloRuntimeStatistics[]>> GetRuntimeStatistics();
 
-        Task<StatCounter[]> GetCounters();
+        Task<Immutable<StatCounter[]>> GetCounters();
     }
 }

--- a/OrleansDashboard/ISiloGrain.cs
+++ b/OrleansDashboard/ISiloGrain.cs
@@ -17,8 +17,10 @@ namespace OrleansDashboard
 
     public interface ISiloGrain : IGrainWithStringKey
     {
+        [OneWay]
         Task SetVersion(string orleans, string host);
 
+        [OneWay]
         Task ReportCounters(Immutable<StatCounter[]> stats);
 
         Task<Immutable<Dictionary<string,string>>> GetExtendedProperties();

--- a/OrleansDashboard/OrleansDashboard.csproj
+++ b/OrleansDashboard/OrleansDashboard.csproj
@@ -35,5 +35,6 @@
     <PackageReference Include="Microsoft.Orleans.Core" Version="$(OrleansPackageVersion)" />
     <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="$(OrleansPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="$(OrleansPackageVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/OrleansDashboard/SiloGrain.cs
+++ b/OrleansDashboard/SiloGrain.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Options;
 using Orleans;
+using Orleans.Concurrency;
 using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
@@ -73,9 +74,9 @@ namespace OrleansDashboard
             }
         }
 
-        public Task<SiloRuntimeStatistics[]> GetRuntimeStatistics()
+        public Task<Immutable<SiloRuntimeStatistics[]>> GetRuntimeStatistics()
         {
-            return Task.FromResult(stats.ToArray());
+            return Task.FromResult(stats.ToArray().AsImmutable());
         }
 
         public Task SetVersion(string orleans, string host)
@@ -86,7 +87,7 @@ namespace OrleansDashboard
             return Task.CompletedTask;
         }
 
-        public Task<Dictionary<string, string>> GetExtendedProperties()
+        public Task<Immutable<Dictionary<string, string>>> GetExtendedProperties()
         {
             var results = new Dictionary<string, string>
             {
@@ -94,12 +95,12 @@ namespace OrleansDashboard
                 ["OrleansVersion"] = versionOrleans
             };
 
-            return Task.FromResult(results);
+            return Task.FromResult(results.AsImmutable());
         }
 
-        public Task ReportCounters(StatCounter[] counters)
+        public Task ReportCounters(Immutable<StatCounter[]> counters)
         {
-            foreach (var counter in counters)
+            foreach (var counter in counters.Value)
             {
                 this.counters[counter.Name] = counter;
             }
@@ -107,9 +108,9 @@ namespace OrleansDashboard
             return Task.CompletedTask;
         }
 
-        public Task<StatCounter[]> GetCounters()
+        public Task<Immutable<StatCounter[]>> GetCounters()
         {
-            return Task.FromResult(counters.Values.OrderBy(x => x.Name).ToArray());
+            return Task.FromResult(counters.Values.OrderBy(x => x.Name).ToArray().AsImmutable());
         }
     }
 }


### PR DESCRIPTION
Almost most calls can be made with immutable parameters or responses. Have not changed GetCounters yet because it is a mutable object.