### PR TITLE
Allow setting a BasePath in self host mode like /dashboard

### DIFF
--- a/OrleansDashboard/Dashboard.cs
+++ b/OrleansDashboard/Dashboard.cs
@@ -57,7 +57,7 @@ namespace OrleansDashboard
                                     app.UseMiddleware<BasicAuthMiddleware>();
                                 }
 
-                                app.UseOrleansDashboard();
+                                app.UseOrleansDashboard(dashboardOptions);
                             })
                             .UseKestrel()
                             .UseUrls($"http://{dashboardOptions.Host}:{dashboardOptions.Port}")

--- a/OrleansDashboard/DashboardOptions.cs
+++ b/OrleansDashboard/DashboardOptions.cs
@@ -16,6 +16,8 @@
 
         public int Port { get; set; } = 8080;
 
+        public string BasePath { get; set; } = "/";
+
         public bool HasUsernameAndPassword()
         {
             return !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password);

--- a/OrleansDashboard/OrleansDashboard.csproj
+++ b/OrleansDashboard/OrleansDashboard.csproj
@@ -8,13 +8,13 @@
     <PackageTags>orleans dashboard metrics monitor</PackageTags>
     <Description>An admin dashboard for Microsoft Orleans</Description>
     <Company>OrleansContrib</Company>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
     <Copyright>Copyright © 2018</Copyright>
     <Authors>OrleansContrib</Authors>
     <PackageIconUrl>http://dotnet.github.io/orleans/assets/logo.png</PackageIconUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <AssemblyVersion>2.0.5</AssemblyVersion>
-    <FileVersion>2.0.5</FileVersion>
+    <AssemblyVersion>2.0.6</AssemblyVersion>
+    <FileVersion>2.0.6</FileVersion>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/OrleansDashboard/ServiceCollectionExtensions.cs
+++ b/OrleansDashboard/ServiceCollectionExtensions.cs
@@ -59,10 +59,19 @@ namespace Orleans
             return builder;
         }
 
-        public static IApplicationBuilder UseOrleansDashboard(this IApplicationBuilder app)
+        public static IApplicationBuilder UseOrleansDashboard(this IApplicationBuilder app, DashboardOptions options = null)
         {
-            app.UseMiddleware<DashboardMiddleware>();
-
+            if (options == null || string.IsNullOrEmpty(options.BasePath) || options.BasePath == "/")
+            {
+                app.UseMiddleware<DashboardMiddleware>();
+            }
+            else
+            {
+                //Make sure there is a leading slash
+                var basePath = options.BasePath.StartsWith("/") ? options.BasePath : "/" + options.BasePath;
+                app.Map(basePath, a => a.UseMiddleware<DashboardMiddleware>());
+            }
+                        
             return app;
         }
 


### PR DESCRIPTION
In self host mode I require that there is a base path such as http://localhost:8000/dashboard.

I added a BasePath string property in DashboardOptions.