### PR TITLE
Info on enabling CPU/Memory metrics.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ new SiloHostBuilder()
 
 Start the silo, and open this url in your browser: [`http://localhost:8080`](http://localhost:8080)
 
-Please note, the CPU and Memory metrics are only enabled on Windows when you add the [Microsoft.Orleans.OrleansTelemetryConsumers.Counters](https://www.nuget.org/packages/Microsoft.Orleans.OrleansTelemetryConsumers.Counters/) package (not supported for .Net Core now).
+Please note, the CPU and Memory metrics are only enabled on Windows when you add the [Microsoft.Orleans.OrleansTelemetryConsumers.Counters](https://www.nuget.org/packages/Microsoft.Orleans.OrleansTelemetryConsumers.Counters/) package and have registered an implementation of  `IHostEnvironmentStatistics` such as with `builder.UsePerfCounterEnvironmentStatistics()` (currently Windows only).
 You also have to wait some time before you see the data.
 
 ## Configuring the Dashboard


### PR DESCRIPTION
Updated the readme to expand on enabling CPU/Memory metrics on the dashboard.  These metrics (at the time of writing) are Windows only, but ***are*** able to be used in .net core; previously it said original framework only.