### PR TITLE
Fix allocations.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <OrleansPackageVersion Condition=" '$(OrleansPackageVersion)'=='' ">2.4.1</OrleansPackageVersion>
-    <DashboardVersion Condition=" '$(DashboardVersion)'=='' ">2.4.3</DashboardVersion>
+    <DashboardVersion Condition=" '$(DashboardVersion)'=='' ">2.4.4</DashboardVersion>
   </PropertyGroup>
 </Project>

--- a/OrleansDashboard.Client/Model/GrainTraceEntry.cs
+++ b/OrleansDashboard.Client/Model/GrainTraceEntry.cs
@@ -39,7 +39,7 @@ namespace OrleansDashboard.Client.Model
 
         public bool Equals(GrainTraceEntry other)
         {
-            return other != null && string.Equals(Grain, other.Grain, StringComparison.OrdinalIgnoreCase) && string.Equals(Method, other.Method, StringComparison.OrdinalIgnoreCase
+            return other != null && string.Equals(Grain, other.Grain, StringComparison.OrdinalIgnoreCase) && string.Equals(Method, other.Method, StringComparison.OrdinalIgnoreCase);
         }
 
         public override int GetHashCode()

--- a/OrleansDashboard.Client/Model/GrainTraceEntry.cs
+++ b/OrleansDashboard.Client/Model/GrainTraceEntry.cs
@@ -15,25 +15,38 @@ namespace OrleansDashboard.Client.Model
         public long ExceptionCount { get; set; }
         public double ElapsedTime { get; set; }
 
-        public int CompareTo(GrainTraceEntry other)
+        public int CompareTo(object obj)
         {
-            return string.Compare(ToString(), other.ToString(), StringComparison.OrdinalIgnoreCase);
+            return obj is GrainTraceEntry entry ? CompareTo(entry) : -1;
         }
 
-        public bool Equals(GrainTraceEntry other) => CompareTo(other) == 0;
+        public int CompareTo(GrainTraceEntry other)
+        {
+            var compared = string.Compare(Grain, other.Grain, StringComparison.OrdinalIgnoreCase);
 
-        public override string ToString() => $"{Grain}.{Method}";
+            if (compared != 0)
+            {
+                return string.Compare(Method, other.Method, StringComparison.OrdinalIgnoreCase);
+            }
 
-        public override int GetHashCode() => ToString().GetHashCode();
+            return compared;
+        }
 
         public override bool Equals(object obj)
         {
             return obj is GrainTraceEntry entry && Equals(entry);
         }
 
-        public int CompareTo(object obj)
+        public bool Equals(GrainTraceEntry other)
         {
-            return obj is GrainTraceEntry entry ? CompareTo(entry) : -1;
+            return other != null && string.Equals(Grain, other.Grain, StringComparison.OrdinalIgnoreCase) && string.Equals(Method, other.Method, StringComparison.OrdinalIgnoreCase
         }
+
+        public override int GetHashCode()
+        {
+            return (Grain?.GetHashCode() ?? 0) ^ (113 * Method?.GetHashCode() ?? 0);
+        }
+
+        public override string ToString() => $"{Grain}.{Method}";
     }
 }

--- a/OrleansDashboard.Client/Model/GrainTraceEntry.cs
+++ b/OrleansDashboard.Client/Model/GrainTraceEntry.cs
@@ -24,7 +24,7 @@ namespace OrleansDashboard.Client.Model
         {
             var compared = string.Compare(Grain, other.Grain, StringComparison.OrdinalIgnoreCase);
 
-            if (compared != 0)
+            if (compared == 0)
             {
                 return string.Compare(Method, other.Method, StringComparison.OrdinalIgnoreCase);
             }

--- a/OrleansDashboard/Metrics/DashboardTelemetryConsumer.cs
+++ b/OrleansDashboard/Metrics/DashboardTelemetryConsumer.cs
@@ -43,6 +43,7 @@ namespace OrleansDashboard
         private readonly ILocalSiloDetails localSiloDetails;
         private readonly IGrainFactory grainFactory;
         private readonly Timer timer;
+        private string siloAddress;
         private bool isClosed;
 
         public DashboardTelemetryConsumer(ILocalSiloDetails localSiloDetails, IGrainFactory grainFactory)
@@ -86,7 +87,12 @@ namespace OrleansDashboard
 
         public void Flush()
         {
-            var grain = grainFactory.GetGrain<ISiloGrain>(localSiloDetails.SiloAddress.ToParsableString());
+            if (siloAddress == null)
+            {
+                siloAddress = localSiloDetails.SiloAddress.ToParsableString();
+            }
+
+            var grain = grainFactory.GetGrain<ISiloGrain>(siloAddress);
 
             var countersArray = metrics.Select(metric => new StatCounter
                 {

--- a/OrleansDashboard/Metrics/GrainProfilerFilter.cs
+++ b/OrleansDashboard/Metrics/GrainProfilerFilter.cs
@@ -1,10 +1,10 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Orleans;
-using Orleans.CodeGeneration;
 
 namespace OrleansDashboard.Metrics
 {
@@ -18,6 +18,7 @@ namespace OrleansDashboard.Metrics
         private readonly GrainMethodFormatterDelegate formatMethodName;
         private readonly IGrainProfiler profiler;
         private readonly ILogger<GrainProfilerFilter> logger;
+        private readonly ConcurrentDictionary<MethodInfo, bool> shouldProfileCache = new ConcurrentDictionary<MethodInfo, bool>();
 
         public GrainProfilerFilter(IGrainProfiler profiler, ILogger<GrainProfilerFilter> logger, GrainMethodFormatterDelegate formatMethodName,
             Func<IIncomingGrainCallContext, string> oldFormatMethodName)
@@ -78,17 +79,22 @@ namespace OrleansDashboard.Metrics
 
         private bool ShouldSkipProfiling(IIncomingGrainCallContext context)
         {
-            try
+            var method = context.ImplementationMethod;
+
+            return shouldProfileCache.GetOrAdd(context.ImplementationMethod, _ =>
             {
-                return
-                    context.Grain.GetType().GetCustomAttribute<NoProfilingAttribute>() != null ||
-                    context.ImplementationMethod?.GetCustomAttribute<NoProfilingAttribute>() != null;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(100003, ex, "error reading NoProfilingAttribute attribute for grain");
-                return false;
-            }
+                try
+                {
+                    return
+                        context.Grain.GetType().GetCustomAttribute<NoProfilingAttribute>() != null ||
+                        context.ImplementationMethod?.GetCustomAttribute<NoProfilingAttribute>() != null;
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(100003, ex, "error reading NoProfilingAttribute attribute for grain");
+                    return false;
+                }
+            });
         }
     }
 }

--- a/OrleansDashboard/Metrics/GrainProfilerFilter.cs
+++ b/OrleansDashboard/Metrics/GrainProfilerFilter.cs
@@ -79,20 +79,22 @@ namespace OrleansDashboard.Metrics
 
         private bool ShouldSkipProfiling(IIncomingGrainCallContext context)
         {
-            var method = context.ImplementationMethod;
+            var grainMethod = context.ImplementationMethod;
 
-            if (method == null)
+            if (grainMethod == null)
             {
                 return false;
             }
 
-            if (!shouldSkipCache.TryGetValue(context.ImplementationMethod, out var shouldSkip))
+            if (!shouldSkipCache.TryGetValue(grainMethod, out var shouldSkip))
             {
                 try
                 {
+                    var grainType = context.Grain.GetType();
+
                     shouldSkip =
-                        context.Grain.GetType().GetCustomAttribute<NoProfilingAttribute>() != null ||
-                        context.ImplementationMethod.GetCustomAttribute<NoProfilingAttribute>() != null;
+                        grainType.GetCustomAttribute<NoProfilingAttribute>() != null ||
+                        grainMethod.GetCustomAttribute<NoProfilingAttribute>() != null;
                 }
                 catch (Exception ex)
                 {

--- a/OrleansDashboard/Metrics/GrainProfilerFilter.cs
+++ b/OrleansDashboard/Metrics/GrainProfilerFilter.cs
@@ -103,7 +103,7 @@ namespace OrleansDashboard.Metrics
                     shouldSkip = false;
                 }
 
-                shouldSkipCache.TryAdd(context.ImplementationMethod, shouldSkip);
+                shouldSkipCache.TryAdd(grainMethod, shouldSkip);
             }
 
             return shouldSkip;

--- a/OrleansDashboard/Metrics/Grains/DashboardGrain.cs
+++ b/OrleansDashboard/Metrics/Grains/DashboardGrain.cs
@@ -22,11 +22,10 @@ namespace OrleansDashboard
     public class DashboardGrain : Grain, IDashboardGrain
     {
         const int DefaultTimerIntervalMs = 1000; // 1 second
-        private static readonly TimeSpan DefaultTimerInterval = TimeSpan.FromSeconds(1);
         private readonly ITraceHistory history = new TraceHistory();
         private readonly DashboardOptions options;
         private readonly ISiloDetailsProvider siloDetailsProvider;
-        private DashboardCounters counters = new DashboardCounters();
+        private readonly DashboardCounters counters = new DashboardCounters();
         private DateTime startTime = DateTime.UtcNow;
 
         public DashboardGrain(IOptions<DashboardOptions> options, ISiloDetailsProvider siloDetailsProvider)

--- a/OrleansDashboard/Metrics/Grains/DashboardGrain.cs
+++ b/OrleansDashboard/Metrics/Grains/DashboardGrain.cs
@@ -1,11 +1,9 @@
 ﻿using Microsoft.Extensions.Options;
 using Orleans;
 using Orleans.Concurrency;
-using Orleans.Placement;
 using Orleans.Runtime;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using OrleansDashboard.Client;
@@ -23,19 +21,27 @@ namespace OrleansDashboard
     {
         const int DefaultTimerIntervalMs = 1000; // 1 second
         private readonly ITraceHistory history = new TraceHistory();
-        private readonly DashboardOptions options;
         private readonly ISiloDetailsProvider siloDetailsProvider;
         private readonly DashboardCounters counters = new DashboardCounters();
+        private TimeSpan updateInterval;
         private DateTime startTime = DateTime.UtcNow;
+        private DateTime lastRefreshTime = DateTime.UtcNow;
 
         public DashboardGrain(IOptions<DashboardOptions> options, ISiloDetailsProvider siloDetailsProvider)
         {
-            this.options = options.Value;
             this.siloDetailsProvider = siloDetailsProvider;
+            this. updateInterval = TimeSpan.FromMilliseconds(Math.Max(options.Value.CounterUpdateIntervalMs, DefaultTimerIntervalMs));
         }
-        
-        private async Task Callback(object _)
+
+        private async Task EnsureCountersAreUpToDate()
         {
+            var now = DateTime.UtcNow;
+
+            if ((now - lastRefreshTime) < updateInterval)
+            {
+                return;
+            }
+
             var metricsGrain = GrainFactory.GetGrain<IManagementGrain>(0);
             var activationCountTask = metricsGrain.GetTotalActivationCount();
             var simpleGrainStatsTask = metricsGrain.GetSimpleGrainStatistics();
@@ -44,6 +50,8 @@ namespace OrleansDashboard
             await Task.WhenAll(activationCountTask,  simpleGrainStatsTask, siloDetailsTask);
 
             RecalculateCounters(activationCountTask.Result, siloDetailsTask.Result, simpleGrainStatsTask.Result);
+
+            lastRefreshTime = now;
         }
 
         internal void RecalculateCounters(int activationCount, SiloDetails[] hosts,
@@ -89,55 +97,53 @@ namespace OrleansDashboard
 
         public override Task OnActivateAsync()
         {
-            var updateInterval =  TimeSpan.FromMilliseconds(Math.Max(options.CounterUpdateIntervalMs, DefaultTimerIntervalMs));
-       
-            try
-            {
-                RegisterTimer(Callback, null, updateInterval, updateInterval);
-            }
-            catch (InvalidOperationException)
-            {
-                Debug.WriteLine("Not running in Orleans runtime");
-            }
-
             startTime = DateTime.UtcNow;
 
             return base.OnActivateAsync();
         }
 
-        public Task<Immutable<DashboardCounters>> GetCounters()
+        public async Task<Immutable<DashboardCounters>> GetCounters()
         {
-            return Task.FromResult(counters.AsImmutable());
+            await EnsureCountersAreUpToDate();
+
+            return counters.AsImmutable();
         }
 
-        public Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain)
+        public async Task<Immutable<Dictionary<string, Dictionary<string, GrainTraceEntry>>>> GetGrainTracing(string grain)
         {
-            return Task.FromResult(history.QueryGrain(grain).AsImmutable());
+            await EnsureCountersAreUpToDate();
+
+            return history.QueryGrain(grain).AsImmutable();
         }
 
-        public Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetClusterTracing()
+        public async Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetClusterTracing()
         {
-            return Task.FromResult(this.history.QueryAll().AsImmutable());
+            await EnsureCountersAreUpToDate();
+
+            return history.QueryAll().AsImmutable();
         }
 
-        public Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetSiloTracing(string address)
+        public async Task<Immutable<Dictionary<string, GrainTraceEntry>>> GetSiloTracing(string address)
         {
-            return Task.FromResult(this.history.QuerySilo(address).AsImmutable());
+            await EnsureCountersAreUpToDate();
+
+            return history.QuerySilo(address).AsImmutable();
         }
 
-        public Task<Immutable<Dictionary<string, GrainMethodAggregate[]>>> TopGrainMethods()
+        public async Task<Immutable<Dictionary<string, GrainMethodAggregate[]>>> TopGrainMethods()
         {
+            await EnsureCountersAreUpToDate();
+
             const int numberOfResultsToReturn = 5;
             
             var values = history.AggregateByGrainMethod().ToList();
             
-            return Task.FromResult(new Dictionary<string, GrainMethodAggregate[]>{
+            return new Dictionary<string, GrainMethodAggregate[]>{
                 { "calls", values.OrderByDescending(x => x.Count).Take(numberOfResultsToReturn).ToArray() },
                 { "latency", values.OrderByDescending(x => x.ElapsedTime / (double) x.Count).Take(numberOfResultsToReturn).ToArray() },
                 { "errors", values.Where(x => x.ExceptionCount > 0 && x.Count > 0).OrderByDescending(x => x.ExceptionCount / x.Count).Take(numberOfResultsToReturn).ToArray() },
-            }.AsImmutable());
+            }.AsImmutable();
         }
-
       
         public Task Init()
         {


### PR DESCRIPTION
I made a memory test of my application and have seen this comparison to be one of the most allocating methods.

This PR fixes several problems:

1. The very inefficient equality checks in GrainTraceEntry.
2. Only update the counters and statistics if needed. There is actually no need to update them if nobody is interested to see them.
3. Allocations from reflection.
4. Allocations in the History from the list.