### PR TITLE
Show full Orleans version

### DIFF
--- a/OrleansDashboard/Dashboard.cs
+++ b/OrleansDashboard/Dashboard.cs
@@ -103,7 +103,10 @@ namespace OrleansDashboard
 
         private static string GetOrleansVersion()
         {
-            return typeof(SiloAddress).GetTypeInfo().Assembly.GetName().Version.ToString();
+            var assembly = typeof(SiloAddress).GetTypeInfo().Assembly;
+            return string.Format("{0} ({1})",
+                assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+                assembly.GetName().Version.ToString());
         }
 
         private static string GetHostVersion()


### PR DESCRIPTION
Now dashboard shows only FileVersion part:
![image](https://user-images.githubusercontent.com/4157587/67011008-727e9f00-f0f7-11e9-847f-b838dcaaf781.png)
while real orleans version _slightly differs_
![image](https://user-images.githubusercontent.com/4157587/67011092-980ba880-f0f7-11e9-9698-69e267f50b4c.png)
