### PR TITLE
Add link to IHostEnvironmentStatistics for AWS ECS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,10 +43,17 @@ You also have to wait some time before you see the data.
 
 ### CPU and Memory Metrics on Linux
 
-Since version 2.3, Orleans includes an implementation of `IHostEnvironmentStatistics` for linux in
+Since version 2.3, Orleans includes an implementation of `IHostEnvironmentStatistics` for Linux in
 [Microsoft.Orleans.OrleansTelemetryConsumers.Linux](https://www.nuget.org/packages/Microsoft.Orleans.OrleansTelemetryConsumers.Linux/).
-To enable CPU and Memory metrics, install the nuget package and add the implementation using to the silo using
+To enable CPU and Memory metrics, install the NuGet package and add the implementation to the silo using
 `siloBuilder.UseLinuxEnvironmentStatistics()`.
+
+### CPU and Memory Metrics on AWS ECS
+
+A community-maintained implementation of `IHostEnvironmentStatistics` for AWS ECS is available in
+[Orleans.TelemetryConsumers.ECS](https://www.nuget.org/packages/Orleans.TelemetryConsumers.ECS/).
+To enable CPU and Memory metrics, install the NuGet package and add the implementation to the silo using
+`siloBuilder.UseEcsTaskHostEnvironmentStatistics()`.
 
 ## Configuring the Dashboard
 


### PR DESCRIPTION
I created an `IHostEnvironmentStatistics` implementation for AWS ECS, and I've been using it in production workloads for almost 9 months. It works for tasks running on both EC2 and Fargate.

I created the package initially to show some quick CPU/memory metrics on the Orleans Dashboard, and I thought others may be interested as well. This PR simply adds a note to the README.