### PR TITLE
fix #296 default color scheme based on OS preference

### DIFF
--- a/Tests/TestHosts/TestHost/index.min.js
+++ b/Tests/TestHosts/TestHost/index.min.js
@@ -1947,6 +1947,11 @@ var storage = require('./lib/storage');
 var target = document.getElementById('content'); // Restore theme preference.
 
 var defaultTheme = storage.get('theme');
+if (!defaultTheme) {
+    // If there is no preferred theme, default to OS preference
+    defaultTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
 defaultTheme === 'dark' ? dark() : light(); // Restore grain visibility preferences.
 
 var settings = {


### PR DESCRIPTION
Hi, 

In the spirit of Hacktoberfest I've given this a go. This will set the theme to the OS preference, but only if no theme preference has been saved to local storage.

I hope this is what you were after - let me know if you have any issues.

Cheers

James