### PR TITLE
Ability to include a custom css file

### DIFF
--- a/OrleansDashboard/DashboardMiddleware.cs
+++ b/OrleansDashboard/DashboardMiddleware.cs
@@ -257,6 +257,12 @@ namespace OrleansDashboard
 
                 content = content.Replace("{{BASE}}", basePath);
                 content = content.Replace("{{HIDE_TRACE}}", options.Value.HideTrace.ToString().ToLowerInvariant());
+                content = content.Replace("{{CUSTOM_CSS}}", options.Value.CustomCssPath switch
+                {
+                    // We're deliberately not escaping path as we're keep things lightweight and we don't want to bring in other dependencies
+                    string path => $@"<link rel=""stylesheet"" type=""text/css"" href=""{path}"" />",
+                    _ => string.Empty
+                }) ;
 
                 await context.Response.WriteAsync(content);
             }

--- a/OrleansDashboard/DashboardOptions.cs
+++ b/OrleansDashboard/DashboardOptions.cs
@@ -15,6 +15,12 @@
         public string ScriptPath { get; set; }
 
         /// <summary>
+        ///   The URL path the dashboard will attempt to load a custom CSS file from on top of the default CSS file
+        ///   The default is null, which will not load in a custom CSS file
+        /// </summary>
+        public string CustomCssPath { get; set; } 
+
+        /// <summary>
         ///   Username for basic auth
         /// </summary>
         public string Username { get; set; }

--- a/OrleansDashboard/Index.html
+++ b/OrleansDashboard/Index.html
@@ -149,6 +149,8 @@
             border: 1px solid #333;
         }
     </style>
+
+    {{CUSTOM_CSS}}
 </head>
   <body class="hold-transition skin-purple sidebar-mini fixed" id="body">
     <div id="error-message-content" class="error-container"></div>


### PR DESCRIPTION
Closes #328 

This is one way of resolving #328 as it allows for the ability to load in a custom css file. I argue its a valid feature as it also enables more advanced scenarios such as replacing the logo and changing colors.

In order to try this out:

1. Create a simple css file like: 
```scss
// custom.css
* {
    font-family: cursive !important;
}
```

2. Ensure that static assets are getting served by middleware
3. Configure orleans to serve this custom css file
```csharp
app.UseStaticFiles();
app.UseOrleansDashboard(new OrleansDashboard.DashboardOptions
{
    CustomCssPath = "/custom.css"
});
```

