### PR TITLE
Converting to WriteAsync to resolve exceptions

### DIFF
--- a/OrleansDashboard/Implementation/TraceWriter.cs
+++ b/OrleansDashboard/Implementation/TraceWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -50,7 +51,7 @@ namespace OrleansDashboard.Implementation
         {
             try
             {
-                await writer.WriteAsync($"{DateTime.UtcNow} {GetLogLevelString(level)}: [{eventId.ToString().PadLeft(8)}] {message}\r\n");
+                await writer.WriteAsync($"{DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)} {GetLogLevelString(level)}: [{eventId.ToString().PadLeft(8)}] {message}\r\n");
 
                 await writer.FlushAsync();
 

--- a/OrleansDashboard/Implementation/TraceWriter.cs
+++ b/OrleansDashboard/Implementation/TraceWriter.cs
@@ -50,7 +50,7 @@ namespace OrleansDashboard.Implementation
         {
             try
             {
-                await writer.WriteAsync($"{DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)} {GetLogLevelString(level)}: [{eventId.ToString().PadLeft(8)}] {message}\r\n");
+                await writer.WriteAsync($"{DateTime.UtcNow} {GetLogLevelString(level)}: [{eventId.ToString().PadLeft(8)}] {message}\r\n");
 
                 await writer.FlushAsync();
 

--- a/OrleansDashboard/Implementation/TraceWriter.cs
+++ b/OrleansDashboard/Implementation/TraceWriter.cs
@@ -34,8 +34,8 @@ namespace OrleansDashboard.Implementation
         {
             try
             {
-                writer.Write(message);
-                writer.Write("\r\n");
+                await writer.WriteAsync(message);
+                await writer.WriteAsync("\r\n");
 
                 await writer.FlushAsync();
 
@@ -50,14 +50,7 @@ namespace OrleansDashboard.Implementation
         {
             try
             {
-                writer.Write(DateTime.UtcNow);
-                writer.Write(" ");
-                writer.Write(GetLogLevelString(level));
-                writer.Write(": [");
-                writer.Write(eventId.ToString().PadLeft(8));
-                writer.Write("] ");
-                writer.Write(message);
-                writer.Write("\r\n");
+                await writer.WriteAsync($"{DateTime.UtcNow.ToString(CultureInfo.InvariantCulture)} {GetLogLevelString(level)}: [{eventId.ToString().PadLeft(8)}] {message}\r\n");
 
                 await writer.FlushAsync();
 


### PR DESCRIPTION
1/26/2022 3:45:57 PM fail: [  100005] Silo Caught an UnobservedTaskException event sent by [Id=1269, Status=Faulted]. Exception = 
Exc level 0: System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.)
Exc level 1: System.InvalidOperationException: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Stream.Write(ReadOnlySpan`1 buffer)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.Write(String value)
   at OrleansDashboard.Implementation.TraceWriter.WriteAsync(EventId eventId, LogLevel level, String message)