### PR TITLE
Ignore() any exceptions from the task in the sync Write method

### DIFF
--- a/OrleansDashboard/Implementation/TraceWriter.cs
+++ b/OrleansDashboard/Implementation/TraceWriter.cs
@@ -29,7 +29,6 @@ namespace OrleansDashboard.Implementation
             var task = WriteAsync(eventId, level, message);
 
             task.Ignore();
-            task.ContinueWith(_ => { /* noop */ });
         }
 
         public async Task WriteAsync(string message)

--- a/OrleansDashboard/Implementation/TraceWriter.cs
+++ b/OrleansDashboard/Implementation/TraceWriter.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Orleans;
 
 namespace OrleansDashboard.Implementation
 {
@@ -27,7 +28,7 @@ namespace OrleansDashboard.Implementation
         {
             var task = WriteAsync(eventId, level, message);
 
-            task.ConfigureAwait(false);
+            task.Ignore();
             task.ContinueWith(_ => { /* noop */ });
         }
 


### PR DESCRIPTION
The private `Write` method - used by TraceListener - calls an async method but does not await or `Ignore()` the task, so any exceptions further down would bubble up and be uncaught, causing the app to crash.

This PR adds an `Ignore()` to the task so that any exceptions are handled - or rather, caught and ignored... and not bubbled up uncaught.

Also removed the unnecessary `ConfigureAwait` and `ContinueWith` calls, as we do not await the task anyway.